### PR TITLE
Feature/chat : WebSocketConfig에 JWT 핸드셰이크 인터셉터 추가

### DIFF
--- a/src/main/java/programo/_pro/config/WebSocketConfig.java
+++ b/src/main/java/programo/_pro/config/WebSocketConfig.java
@@ -1,18 +1,25 @@
 package programo._pro.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import programo._pro.config.jwt.JwtHandshakeInterceptor;
+import programo._pro.config.jwt.JwtTokenProvider;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+	private final JwtTokenProvider jwtTokenProvider;
+
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws-chat")
+				.addInterceptors(new JwtHandshakeInterceptor(jwtTokenProvider))
 				.setAllowedOriginPatterns("*")
 				.withSockJS();
 	}

--- a/src/main/java/programo/_pro/config/jwt/JwtHandshakeInterceptor.java
+++ b/src/main/java/programo/_pro/config/jwt/JwtHandshakeInterceptor.java
@@ -1,0 +1,51 @@
+package programo._pro.config.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public boolean beforeHandshake(ServerHttpRequest request,
+								   ServerHttpResponse response,
+								   WebSocketHandler webSocketHandler,
+								   Map<String, Object> attributes) throws Exception{
+
+		HttpServletRequest servletRequest = ((ServletServerHttpRequest) request).getServletRequest();
+		String token = servletRequest.getParameter("token");
+
+		// 프론트측에서 /ws-chat으로 연결 테스트해야 나타나는 로그
+		log.info("[WebSocket] Attempting handshake...");
+		log.info("[WebSocket] Received token: {}", token);
+
+		if (token != null && jwtTokenProvider.validateToken(token)) {
+			String userId = jwtTokenProvider.getUserIdFromToken(token);
+			attributes.put("userId", userId);
+			log.info("[WebSocket] JWT validation successful. userId: {}", userId);
+		}
+		log.warn("[WebSocket] JWT validation failed. Connection denied.");
+		return false;
+
+	}
+
+	@Override
+	public void afterHandshake(ServerHttpRequest request,
+							   ServerHttpResponse response,
+							   WebSocketHandler wsHandler,
+							   Exception exception) {
+
+	}
+
+
+}

--- a/src/main/java/programo/_pro/config/jwt/JwtHandshakeInterceptor.java
+++ b/src/main/java/programo/_pro/config/jwt/JwtHandshakeInterceptor.java
@@ -33,6 +33,7 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 			String userId = jwtTokenProvider.getUserIdFromToken(token);
 			attributes.put("userId", userId);
 			log.info("[WebSocket] JWT validation successful. userId: {}", userId);
+			return true;
 		}
 		log.warn("[WebSocket] JWT validation failed. Connection denied.");
 		return false;

--- a/src/main/java/programo/_pro/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/programo/_pro/config/jwt/JwtTokenProvider.java
@@ -14,7 +14,7 @@ public class JwtTokenProvider {
 
 	public boolean validateToken(String token) {
 		try{
-			Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build().parseClaimsJwt(token);
+			Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build().parseClaimsJws(token);
 			return true;
 		}
 		catch (Exception e){
@@ -27,7 +27,7 @@ public class JwtTokenProvider {
 		return Jwts.parserBuilder()
 				.setSigningKey(secretKey.getBytes())
 				.build()
-				.parseClaimsJwt(token)
+				.parseClaimsJws(token)
 				.getBody()
 				.getSubject();
 	}

--- a/src/main/java/programo/_pro/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/programo/_pro/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,34 @@
+package programo._pro.config.jwt;
+
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+	@Value("${jwt.secret}")
+	private String secretKey;
+
+	public boolean validateToken(String token) {
+		try{
+			Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build().parseClaimsJwt(token);
+			return true;
+		}
+		catch (Exception e){
+			log.warn("[JWT] Invalid token: {}", e.getMessage());
+			return false;
+		}
+	}
+
+	public String getUserIdFromToken(String token) {
+		return Jwts.parserBuilder()
+				.setSigningKey(secretKey.getBytes())
+				.build()
+				.parseClaimsJwt(token)
+				.getBody()
+				.getSubject();
+	}
+}

--- a/src/main/java/programo/_pro/config/security/SecurityConfig.java
+++ b/src/main/java/programo/_pro/config/security/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .headers(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(request -> request
+                        // websocket 경로는 permitAll()로 명시
+                        .requestMatchers("/ws-chat/**").permitAll()
                         // 개발환경에서는 모든 요청 허용
                         .anyRequest().permitAll()
                 )


### PR DESCRIPTION
## 🔗 관련 이슈 번호 <!--- ex) 이슈 번호를 작성해주세요 close #11 -->

- Closes #11

## 🛠️ PR 유형
<!-- 어떤 변경 사항이 있나요? -->
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 작업 내용

- JwtHandshakeInterceptor 클래스 구현
  - WebSocket 연결 시 전달받은 토큰을 검증하여 userId를 WebSocket 세션에 저장
- JwtTokenProvider 작성
  - JWT 유효성 검사 및 userId 추출 로직 구현

<!-- 예: 로그인 UI 수정, API 연결, 유효성 검사 추가 등 -->

## ✅ 변경 사항

- WebSocketConfig 수정
  - 인터셉터 등록을 위해 JwtTokenProvider 의존성 주입 및 endpoint 설정 수정


<!-- 예: - UI 버튼 위치 변경
- 로그인 실패 시 에러 메시지 추가
- API 연결 시 토큰 헤더 포함  -->

## 📸 스크린샷 (선택)

## 💬 코멘트

@S2ej1n 
### 프론트엔드 작업 안내 (채팅 기능 연동)
아래는 간단히 작성한 WebSocket + STOMP 기반 채팅 연동 **예시**입니다.
프론트에서는 JWT 토큰을 함께 전달하여 WebSocket 연결을 시도하고,
`/pub`과 `/sub` 경로를 통해 메시지를 주고받을 수 있습니다.

#### 1️⃣ WebSocket 연결

```js
const socket = new SockJS("http://localhost:8080/ws-chat?token=" + accessToken);
const stompClient = Stomp.over(socket);

stompClient.connect({}, () => {
  // 연결 완료 후 메시지 구독 및 전송 처리
});
```

- accessToken은 로그인 후 발급된 JWT 토큰을 사용해주세요
- 연결 실패 시 토큰 누락/만료 여부 확인


#### 2️⃣ 메시지 구독

```js
stompClient.subscribe("/sub/chat/room/" + ChatRoomId (message) => {
  const payload = JSON.parse(message.body);
  // 메시지 출력 or 화면 렌더링
});
```

#### 3️⃣ 메시지 전송

```js
stompClient.send("/pub/chat/message", {}, JSON.stringify({
  chatRoomId: 1,           // 채팅방 ID
  userId: 1,          // 로그인한 유저 ID
  content: "메시지 내용",
  // 그외...
}));

```