### PR TITLE
Feature/team list : teamList 페이지 api 구현 (정렬, 검색 포함)

### DIFF
--- a/src/main/java/programo/_pro/controller/TeamController.java
+++ b/src/main/java/programo/_pro/controller/TeamController.java
@@ -20,10 +20,11 @@ public class TeamController {
 
     @GetMapping
     public ResponseEntity<List<TeamCardDto>> getAllTeams(
+            @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam(value = "level", required = false) String level,
             @RequestParam(value = "sort", required = false) String sort
     ) {
-        List<TeamCardDto> teamCards = teamService.getAllTeams(level, sort);
+        List<TeamCardDto> teamCards = teamService.getAllTeams(keyword, level, sort);
         return ResponseEntity.ok(teamCards);
     }
 }

--- a/src/main/java/programo/_pro/controller/TeamController.java
+++ b/src/main/java/programo/_pro/controller/TeamController.java
@@ -1,0 +1,25 @@
+package programo._pro.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import programo._pro.dto.TeamCardDto;
+import programo._pro.service.TeamService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @GetMapping
+    public ResponseEntity<List<TeamCardDto>> getAllTeams() {
+        List<TeamCardDto> teamCards = teamService.getAllTeams();
+        return ResponseEntity.ok(teamCards);
+    }
+}

--- a/src/main/java/programo/_pro/controller/TeamController.java
+++ b/src/main/java/programo/_pro/controller/TeamController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import programo._pro.dto.TeamCardDto;
 import programo._pro.service.TeamService;
@@ -18,8 +19,11 @@ public class TeamController {
     private final TeamService teamService;
 
     @GetMapping
-    public ResponseEntity<List<TeamCardDto>> getAllTeams() {
-        List<TeamCardDto> teamCards = teamService.getAllTeams();
+    public ResponseEntity<List<TeamCardDto>> getAllTeams(
+            @RequestParam(value = "level", required = false) String level,
+            @RequestParam(value = "sort", required = false) String sort
+    ) {
+        List<TeamCardDto> teamCards = teamService.getAllTeams(level, sort);
         return ResponseEntity.ok(teamCards);
     }
 }

--- a/src/main/java/programo/_pro/dto/TeamCardDto.java
+++ b/src/main/java/programo/_pro/dto/TeamCardDto.java
@@ -1,0 +1,15 @@
+package programo._pro.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TeamCardDto {
+    private Long teamId;
+    private String teamName;
+    private String level;
+    private String startTime;
+    private int problemCount;
+    private int currentMembers;
+}

--- a/src/main/java/programo/_pro/entity/Level.java
+++ b/src/main/java/programo/_pro/entity/Level.java
@@ -1,0 +1,5 @@
+package programo._pro.entity;
+
+public enum Level {
+    하, 중, 상
+}

--- a/src/main/java/programo/_pro/entity/Team.java
+++ b/src/main/java/programo/_pro/entity/Team.java
@@ -18,7 +18,7 @@ public class Team {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "team_name", nullable = false, unique = true)
+	@Column(name = "team_name", nullable = false)
 	private String teamName;
 
 	@Column(name = "description")

--- a/src/main/java/programo/_pro/entity/Team.java
+++ b/src/main/java/programo/_pro/entity/Team.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -43,8 +44,9 @@ public class Team {
 	@Column(name = "leader_id", nullable = false)
 	private Long leaderId; // FK
 
+	@CreationTimestamp
 	@Column(name = "created_at", updatable = false)
-	private LocalDateTime createdAt = LocalDateTime.now();
+	private LocalDateTime createdAt;
 
 	@Column(name = "is_active")
 	private boolean isActive = true;

--- a/src/main/java/programo/_pro/entity/Team.java
+++ b/src/main/java/programo/_pro/entity/Team.java
@@ -2,17 +2,50 @@ package programo._pro.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "team")
 @Getter
 @Setter
+@NoArgsConstructor
 public class Team {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "team_name", nullable = false)
+	@Column(name = "team_name", nullable = false, unique = true)
 	private String teamName;
+
+	@Column(name = "description")
+	private String description;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "level", nullable = false)
+	private Level level;  // ENUM
+
+	@Column(name = "problem_count", nullable = false)
+	private int problemCount;
+
+	@Column(name = "start_time", nullable = false)
+	private LocalDateTime startTime;
+
+	@Column(name = "duration_time", nullable = false)
+	private int durationTime;
+
+	@Column(name = "current_members", nullable = false)
+	private int currentMembers;
+
+	@Column(name = "leader_id", nullable = false)
+	private Long leaderId; // FK
+
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt = LocalDateTime.now();
+
+	@Column(name = "is_active")
+	private boolean isActive = true;
 }

--- a/src/main/java/programo/_pro/repository/TeamRepository.java
+++ b/src/main/java/programo/_pro/repository/TeamRepository.java
@@ -1,0 +1,9 @@
+package programo._pro.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import programo._pro.entity.Team;
+import java.util.List;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    List<Team> findByIsActiveTrue();
+}

--- a/src/main/java/programo/_pro/service/TeamService.java
+++ b/src/main/java/programo/_pro/service/TeamService.java
@@ -9,6 +9,7 @@ import programo._pro.repository.TeamRepository;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -37,12 +38,14 @@ public class TeamService {
             teams.sort(Comparator.comparing(Team::getCurrentMembers).reversed());
         }
 
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+
         return teams.stream()
                 .map(team -> TeamCardDto.builder()
                         .teamId(team.getId())
                         .teamName(team.getTeamName())
                         .level(team.getLevel().name())
-                        .startTime(team.getStartTime().toString()) //포맷 변경 필요 !!!!!
+                        .startTime(team.getStartTime().format(timeFormatter))
                         .problemCount(team.getProblemCount())
                         .currentMembers(team.getCurrentMembers())
                         .build())

--- a/src/main/java/programo/_pro/service/TeamService.java
+++ b/src/main/java/programo/_pro/service/TeamService.java
@@ -1,0 +1,32 @@
+package programo._pro.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import programo._pro.dto.TeamCardDto;
+import programo._pro.entity.Team;
+import programo._pro.repository.TeamRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+
+    public List<TeamCardDto> getAllTeams() {
+        List<Team> teams = teamRepository.findByIsActiveTrue();
+
+        return teams.stream()
+                .map(team -> TeamCardDto.builder()
+                        .teamId(team.getId())
+                        .teamName(team.getTeamName())
+                        .level(team.getLevel().name())
+                        .startTime(team.getStartTime().toString()) //포맷 변경 필요 !!!!!
+                        .problemCount(team.getProblemCount())
+                        .currentMembers(team.getCurrentMembers())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/programo/_pro/service/TeamService.java
+++ b/src/main/java/programo/_pro/service/TeamService.java
@@ -17,8 +17,18 @@ public class TeamService {
 
     private final TeamRepository teamRepository;
 
-    public List<TeamCardDto> getAllTeams(String level, String sort) {
+    public List<TeamCardDto> getAllTeams(String keyword, String level, String sort) {
         List<Team> teams = teamRepository.findByIsActiveTrue();
+
+        // 키워드 필터링 (팀이름에 포함되는 경우), 대소문자 구분없이 검색가능
+        if (keyword != null && !keyword.isBlank()) {
+            String lowerKeyword = keyword.toLowerCase();
+            teams = teams.stream()
+                    .filter(team ->
+                            team.getTeamName().toLowerCase().contains(lowerKeyword)
+                    )
+                    .collect(Collectors.toList());
+        }
 
         // 난이도 선택 안할경우 all이 디폴트
         if (level != null && !level.equalsIgnoreCase("all")) {

--- a/src/main/java/programo/_pro/service/TeamService.java
+++ b/src/main/java/programo/_pro/service/TeamService.java
@@ -6,6 +6,7 @@ import programo._pro.dto.TeamCardDto;
 import programo._pro.entity.Team;
 import programo._pro.repository.TeamRepository;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,8 +16,26 @@ public class TeamService {
 
     private final TeamRepository teamRepository;
 
-    public List<TeamCardDto> getAllTeams() {
+    public List<TeamCardDto> getAllTeams(String level, String sort) {
         List<Team> teams = teamRepository.findByIsActiveTrue();
+
+        // 난이도 선택 안할경우 all이 디폴트
+        if (level != null && !level.equalsIgnoreCase("all")) {
+            teams = teams.stream()
+                    .filter(team -> team.getLevel().name().equalsIgnoreCase(level))
+                    .collect(Collectors.toList());
+        }
+
+        // 정렬 선택 안할경우 최신순이 디폴트
+        if (sort == null || sort.isBlank() || sort.equalsIgnoreCase("createdAt")) {
+            teams.sort(Comparator.comparing(Team::getCreatedAt).reversed());
+        } else if ("problemCount".equals(sort)) {
+            teams.sort(Comparator.comparing(Team::getProblemCount).reversed());
+        } else if ("name".equals(sort)) {
+            teams.sort(Comparator.comparing(Team::getTeamName));
+        } else if ("currentMembers".equals(sort)) {
+            teams.sort(Comparator.comparing(Team::getCurrentMembers).reversed());
+        }
 
         return teams.stream()
                 .map(team -> TeamCardDto.builder()


### PR DESCRIPTION
## 🔗 관련 이슈 번호 <!--- ex) 이슈 번호를 작성해주세요 close #11 -->

- Closes #8 

## 🛠️ PR 유형
<!-- 어떤 변경 사항이 있나요? -->
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 작업 내용

팀 리스트 조회 API 구현

- 팀 리스트 페이지에 필요한 팀정보만 TeamCardDto에 넣었습니다 !
- 기본 정렬 필터링 (문제 개수 많은 순서 / 이름 순서 / 팀 생성일 순서 / 인원 많은 순서)
- default는 팀 생성일 순서로 설정
- 난이도 필터링 (all / 상 / 중 / 하)
- default는 all로 설정
- 검색 기능
- 소문자 구분 없이 검색 가능

검색, 난이도 필터링, 기본 정렬 필터링 기능은 각각 또는 함께 설정 가능합니다

## ✅ 변경 사항

- team entity파일 수정
- teamList 관련 파일 추가, 기능 구현

## 💬 코멘트

- 예제 데이터로 api 테스트 완료
