### PR TITLE
Feature/mypage 회원탈퇴 기능 

### DIFF
--- a/src/main/java/programo/_pro/config/security/SecurityConfig.java
+++ b/src/main/java/programo/_pro/config/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package programo._pro.config.security;
 
 import programo._pro.global.filter.JwtAuthFilter;
 import programo._pro.global.filter.JwtAuthenticationFilter;
+import programo._pro.repository.UserRepository;
 import programo._pro.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +26,7 @@ public class SecurityConfig {
     private final UserDetailsService customUserDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-
+    private final UserRepository userRepository;
 //   사용자 인증을 처리하는 핵심 매니저 객체를 꺼내서 Bean으로 등록하는 함수
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
@@ -35,7 +36,7 @@ public class SecurityConfig {
 //    클라이언트가 로그인 요청을 보냈을 때, 아이디/비밀번호를 인증하고 JWT를 생성하는 필터
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, userRepository);
         filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
         return filter;
     }
@@ -61,7 +62,7 @@ public class SecurityConfig {
                         // 개발환경에서는 모든 요청 허용 -> 추후 운영서버는 수정
                         .anyRequest().permitAll()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class) // JWT 검증 필터 삽입
+                .addFilterBefore(new JwtAuthenticationFilter(jwtService, userRepository), UsernamePasswordAuthenticationFilter.class) // JWT 검증 필터 삽입
                 .addFilterAfter(new JwtAuthFilter(customUserDetailsService, jwtService), UsernamePasswordAuthenticationFilter.class) // JWT 검증 필터 삽입
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint));
         return http.build();

--- a/src/main/java/programo/_pro/controller/AuthController.java
+++ b/src/main/java/programo/_pro/controller/AuthController.java
@@ -26,6 +26,7 @@ public class AuthController {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
+    @Operation(summary = "회원가입", description = "입력한 정보로 회원가입")
     @PostMapping("/join")
     public ResponseEntity<ApiResponse<User>> signUp(@RequestBody @Valid SignUpDto signUpDto) {
         return ResponseEntity.ok(ApiResponse.success(authService.signUp(signUpDto.toService())));
@@ -53,6 +54,7 @@ public class AuthController {
     }
 
     // 비밀번호 초기화 후 임시비밀번호를 입력해서 로그인 시도할 때 값 검증 메서드
+    @Operation(summary = "임시 비밀번호값 검증", description = "비밀번호 초기화 후 임시비밀번호를 입력해서 로그인 시도할 때 값 검증 메서드")
     @PostMapping("/verify")
     public ResponseEntity<ApiResponse<String>> authenticate(@RequestBody @Valid SignInDto signInDto) {
         boolean isMatch = authService.authenticate(signInDto.getEmail(), signInDto.getPassword());

--- a/src/main/java/programo/_pro/controller/HistoryController.java
+++ b/src/main/java/programo/_pro/controller/HistoryController.java
@@ -1,0 +1,16 @@
+package programo._pro.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/history")
+@Slf4j
+@RequiredArgsConstructor
+@Tag(name = "히스토리 페이지", description = "히스토리 페이지 API")
+public class HistoryController {
+
+}

--- a/src/main/java/programo/_pro/controller/MyPageController.java
+++ b/src/main/java/programo/_pro/controller/MyPageController.java
@@ -37,5 +37,11 @@ public class MyPageController {
          return ResponseEntity.ok(ApiResponse.success("success", "성공적으로 회원정보를 업데이트했습니다."));
     }
 
+    @PatchMapping("/delete/{userId}")
+    public ResponseEntity<ApiResponse<String>> deleteUser(@PathVariable int userId) {
+        myPageService.deleteUser(userId);
+
+        return ResponseEntity.ok(ApiResponse.success("success", "성공적으로 회원정보를 삭제했습니다."));
+    }
 
 }

--- a/src/main/java/programo/_pro/controller/MyPageController.java
+++ b/src/main/java/programo/_pro/controller/MyPageController.java
@@ -1,5 +1,7 @@
 package programo._pro.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ public class MyPageController {
 
     // 이름, 이메일을 가져옴
     @GetMapping("/{userId}")
+    @Operation(summary = "회원정보 조회", description = "userId 값으로 회원정보 수정 페이지에 필요한 데이터를 가져옵니다")
     public ResponseEntity<ApiResponse<UserDto>> getUser(@PathVariable int userId) {
         UserDto userDto =  myPageService.getUser(userId);
 
@@ -31,6 +34,7 @@ public class MyPageController {
 
     // 유저 id 를 받고, body 로 들어온 정보로 업데이트
     @PatchMapping("/update/{userId}")
+    @Operation(summary = "회원정보 업데이트", description = "해당 userId의 데이터를 수정합니다.")
     public ResponseEntity<ApiResponse<String>> updateUserInfo(@PathVariable int userId, @RequestBody @Valid UserInfoUpdateDto userInfoUpdateDto) {
          myPageService.updateUserInfo(userId, userInfoUpdateDto);
 
@@ -38,6 +42,7 @@ public class MyPageController {
     }
 
     @PatchMapping("/delete/{userId}")
+    @Operation(summary = "회원정보 삭제", description = "해당 userId의 회원정보를 삭제합니다.")
     public ResponseEntity<ApiResponse<String>> deleteUser(@PathVariable int userId) {
         myPageService.deleteUser(userId);
 

--- a/src/main/java/programo/_pro/controller/UserController.java
+++ b/src/main/java/programo/_pro/controller/UserController.java
@@ -1,5 +1,7 @@
 package programo._pro.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,9 +22,9 @@ import programo._pro.service.UserService;
 public class UserController {
     private final UserService userService;
 
-
+    @Operation(summary = "회원정보 조회", description = "userId 값으로 해당 회원 정보 조회")
     @GetMapping("/{userId}")
-    public ResponseEntity<ApiResponse<UserDto>> getUserById(@PathVariable int userId) {
+    public ResponseEntity<ApiResponse<UserDto>> getUserById(@Parameter(description = "회원의 id(PK)") @PathVariable int userId) {
         UserDto user = userService.getUserById(userId);
 
         if (user == null) {

--- a/src/main/java/programo/_pro/dto/AuthenticationToken.java
+++ b/src/main/java/programo/_pro/dto/AuthenticationToken.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 public class AuthenticationToken implements UserDetails {
+    private final Long id;
     private final String email;
     private final String password;
 
@@ -31,6 +32,8 @@ public class AuthenticationToken implements UserDetails {
     public String getUsername() {
         return email;
     }
+
+    public Long getId(){ return id; }
 
     /**
      * 이메일을 반환하는 편의 메서드
@@ -61,6 +64,6 @@ public class AuthenticationToken implements UserDetails {
     }
 
     public static AuthenticationToken of(User u) {
-        return new AuthenticationToken(u.getEmail(), u.getPassword());
+        return new AuthenticationToken(u.getId(), u.getEmail(), u.getPassword());
     }
 }

--- a/src/main/java/programo/_pro/dto/AuthenticationToken.java
+++ b/src/main/java/programo/_pro/dto/AuthenticationToken.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 public class AuthenticationToken implements UserDetails {
-    private final Long id;
+    private final Long id; // userId
     private final String email;
     private final String password;
 

--- a/src/main/java/programo/_pro/dto/JwtUserInfoDto.java
+++ b/src/main/java/programo/_pro/dto/JwtUserInfoDto.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class JwtUserInfoDto {
+    private long Id;
     private String email;
 }

--- a/src/main/java/programo/_pro/dto/authDto/DupCheckDto.java
+++ b/src/main/java/programo/_pro/dto/authDto/DupCheckDto.java
@@ -1,9 +1,11 @@
 package programo._pro.dto.authDto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class DupCheckDto {
 
+    @Schema(description = "사용자 이메일", example = "test123@example.com")
     private String email;
 }

--- a/src/main/java/programo/_pro/dto/authDto/SignInDto.java
+++ b/src/main/java/programo/_pro/dto/authDto/SignInDto.java
@@ -2,6 +2,7 @@ package programo._pro.dto.authDto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SignInDto {
+
+    @Schema(description = "사용자 이메일", example = "test123@example.com")
     private String email;
+
+    @Schema(description = "사용자 비밀번호", example = "test123!@")
     private String password;
 }

--- a/src/main/java/programo/_pro/dto/authDto/SignUpDto.java
+++ b/src/main/java/programo/_pro/dto/authDto/SignUpDto.java
@@ -2,6 +2,7 @@ package programo._pro.dto.authDto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -13,10 +14,12 @@ import programo._pro.dto.userDto.UserInfo;
 public class SignUpDto {
 
     @Email
+    @Schema(description = "사용자 이메일", example = "test123@example.com")
     private String email;
 
     @Size(max = 8, message = "닉네임은 최대 8자까지 가능합니다.")
     @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "닉네임은 영문자와 숫자만 사용할 수 있습니다.")
+    @Schema(description = "사용자 닉네임", example = "dongdong123")
     private String username;
 
     // 한글, 공백, 이모지 자동 차단
@@ -25,6 +28,7 @@ public class SignUpDto {
             message = "비밀번호는 8~20자이며, 영문자, 숫자, ~!@#$%^&*? 중 하나 이상의 특수문자를 포함해야 합니다."
     )
     @Size(min = 8, max = 20, message = "비밀번호는 8~20자여야 합니다.")
+    @Schema(description = "사용자 비밀번호", example = "test123!@")
     private String password;
 
     // 내부 처리용 DTO

--- a/src/main/java/programo/_pro/dto/userDto/UserInfoUpdateDto.java
+++ b/src/main/java/programo/_pro/dto/userDto/UserInfoUpdateDto.java
@@ -1,5 +1,6 @@
 package programo._pro.dto.userDto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -15,6 +16,7 @@ public class UserInfoUpdateDto {
             regexp = "^[a-zA-Z0-9가-힣]*$", // 한글 닉네임도 가능
             message = "닉네임은 한글, 영문자, 숫자만 사용할 수 있습니다."
     )
+    @Schema(description = "사용자 닉네임", example = "엄준식")
     private String username;
 
     // 한글, 공백, 이모지 자동 차단
@@ -23,5 +25,6 @@ public class UserInfoUpdateDto {
             message = "비밀번호는 8~20자이며, 영문자, 숫자, ~!@#$%^&*? 중 하나 이상의 특수문자를 포함해야 합니다."
     )
     @Size(min = 8, max = 20, message = "비밀번호는 8~20자여야 합니다.")
+    @Schema(description = "사용자 비밀번호", example = "test!123")
     private String password;
 }

--- a/src/main/java/programo/_pro/global/filter/JwtAuthFilter.java
+++ b/src/main/java/programo/_pro/global/filter/JwtAuthFilter.java
@@ -1,5 +1,6 @@
 package programo._pro.global.filter;
 
+import programo._pro.service.CustomUserDetailsService;
 import programo._pro.service.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -24,7 +25,8 @@ import java.io.IOException;
 토큰이 없거나 유효하지 않으면 인증 오류 반환 */
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
-    private final UserDetailsService userDetailsService;
+//    private final UserDetailsService userDetailsService;
+    private final CustomUserDetailsService customUserDetailsService;
     private final JwtService jwtService;
 
     @Override
@@ -36,7 +38,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 String token = authorizationHeader.substring(7);
                 if (jwtService.validateAccessToken(token, response)) {
                     String email = jwtService.getUserEmail(token);
-                    UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                    UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
 
                     if (userDetails != null) {
                         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/programo/_pro/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/programo/_pro/global/filter/JwtAuthenticationFilter.java
@@ -1,21 +1,26 @@
 package programo._pro.global.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import programo._pro.dto.*;
-import programo._pro.dto.authDto.SignInDto;
-import programo._pro.global.ApiResponse;
-import programo._pro.global.ErrorResponse;
-import programo._pro.service.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import programo._pro.dto.AuthenticationToken;
+import programo._pro.dto.JwtUserInfoDto;
+import programo._pro.dto.authDto.SignInDto;
+import programo._pro.entity.User;
+import programo._pro.global.ApiResponse;
+import programo._pro.global.ErrorResponse;
+import programo._pro.global.exception.userException.NotFoundUserException;
+import programo._pro.repository.UserRepository;
+import programo._pro.service.JwtService;
 
 import java.io.IOException;
 
@@ -24,14 +29,19 @@ import java.io.IOException;
 로그인 요청("/api/v1/auth/login")에서 사용자 자격 증명(ID/비밀번호)을 확인
 인증 성공 시 JWT 토큰 생성 및 발급
 인증 실패 시 에러 응답 반환 */
+@Slf4j
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
     private final JwtService jwtService;
+    private final UserRepository userRepository;
     private final boolean postOnly = true;
 
-    public JwtAuthenticationFilter(JwtService jwtService) {
+    public JwtAuthenticationFilter(JwtService jwtService, UserRepository userRepository) {
         this.jwtService = jwtService;
+        this.userRepository = userRepository;
+
         setFilterProcessesUrl("/api/auth/login"); // 이 필터가 처리할 url 직접 지정
     }
+
 
     // 로그인 시도 시 자동 호출하고 인증 로직 처리 로직 실행
     @Override
@@ -44,12 +54,28 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                 String email = requestDto.getEmail();
                 String password = requestDto.getPassword();
 
+                User user = userRepository.findByEmail(email)
+                        .orElseThrow(() -> new AuthenticationServiceException("존재하지 않는 사용자입니다.")); // 로그인 실패 예외 던짐
+
+                if (!user.isActive()) {
+                    throw new AuthenticationServiceException("탈퇴한 계정이거나 존재하지 않습니다."); // 로그인 실패 예외 던짐
+                }
+
                 // 받아온 이메일, 패스워드 정보를 이용해 이메일이 존재하고, 비밀번호가 일치하면 성공 -> 성공시 인증정보가 담긴 객체 반환
                 return getAuthenticationManager().authenticate(new UsernamePasswordAuthenticationToken(email, password));
 
             } catch (IOException e) {
-                // 추후 구체화 된 예외로 변경
-                throw new RuntimeException(e);
+
+                throw new RuntimeException(e); // 이외의 예외를 런타임 예외로 던져버림
+            }
+            catch (AuthenticationException e) { // 로그인 실패 예외를 잡음
+                // 여기서 실패 처리 메소드를 직접 호출하고 null 반환
+                try {
+                    unsuccessfulAuthentication(request, response, e); // 실페 처리 메서드 호출
+                } catch (IOException ex) {
+                    throw new RuntimeException(ex); // 그럼에도 못잡았으면 런타임 예외 던짐
+                }
+                return null;
             }
         }
     }
@@ -71,6 +97,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     }
 
     // 로그인 실패 시 스프링 시큐리티 내부에서 자동 호출
+    // 여기서 로그인 예외를 잡아서 ErrorResponse 객체로 응답
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED.value(), failed.getMessage(), "/login", "아이디와 비밀번호가 올바르지 않습니다.");

--- a/src/main/java/programo/_pro/service/CustomUserDetailsService.java
+++ b/src/main/java/programo/_pro/service/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package programo._pro.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import programo._pro.dto.AuthenticationToken;
+import programo._pro.entity.User;
+import programo._pro.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        // 이메일을 기준으로 user 정보를 조회하고, 없으면 예외 발생
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일의 사용자를 찾을 수 없습니다: " + email));
+
+        // 조회된 유저의 id, email, password를 담은 커스텀 UserDetails 객체(AuthenticationToken)를 반환
+        // 이 객체는 Spring Security의 인증 과정에서 사용자 정보로 사용됨
+        return new AuthenticationToken(user.getId(), user.getEmail(), user.getPassword());
+    }
+}

--- a/src/main/java/programo/_pro/service/HistoryService.java
+++ b/src/main/java/programo/_pro/service/HistoryService.java
@@ -1,0 +1,7 @@
+package programo._pro.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class HistoryService {
+}

--- a/src/main/java/programo/_pro/service/JwtService.java
+++ b/src/main/java/programo/_pro/service/JwtService.java
@@ -53,7 +53,7 @@ public class JwtService {
     public String createToken(JwtUserInfoDto member) {
         Claims claims = Jwts.claims();
         claims.put("email", member.getEmail()); // 이메일을 토큰에 삽입
-        claims.put("id", member.getId()); // user_id를 토큰에 삽입
+        claims.put("userId", member.getId()); // user_id를 토큰에 삽입
 
         String accessToken = generateAccessToken(member);
         String refreshToken = generateRefreshToken(member);
@@ -65,7 +65,7 @@ public class JwtService {
     public String createToken(JwtUserInfoDto member, Instant expiredTime) {
         Claims claims = Jwts.claims();
         claims.put("email", member.getEmail()); // 이메일을 토큰에 삽입
-        claims.put("id", member.getId()); // user_id를 토큰에 삽입
+        claims.put("userId", member.getId()); // user_id를 토큰에 삽입
         Date expires = Date.from(expiredTime); //
 
         return makeToken(key, claims, expires);
@@ -85,7 +85,7 @@ public class JwtService {
     private String generateAccessToken(JwtUserInfoDto member) {
         Claims claims = Jwts.claims();
         claims.put("email", member.getEmail()); // 토큰에 이메일 삽입
-        claims.put("id", member.getId()); // 토큰에 id 삽입
+        claims.put("userId", member.getId()); // 토큰에 id 삽입
 
         long now = (new Date()).getTime();
         Date expires = new Date(now + accessTokenExpireTime);
@@ -97,7 +97,7 @@ public class JwtService {
     private String generateRefreshToken(JwtUserInfoDto member) {
         Claims claims = Jwts.claims();
         claims.put("email", member.getEmail()); // 토큰에 이메일 삽입
-        claims.put("id", member.getId()); // 토큰에 id 삽입
+        claims.put("userId", member.getId()); // 토큰에 id 삽입
 
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime expires = now.plusSeconds(refreshTokenExpireTime);

--- a/src/main/java/programo/_pro/service/JwtService.java
+++ b/src/main/java/programo/_pro/service/JwtService.java
@@ -29,7 +29,7 @@ public class JwtService {
 
     private static final long ONE_SECOND = 1000;
     private static final long ONE_MINUTE = ONE_SECOND * 60;
-    private static final String EMAIL_KEY = "email";
+//    private static final String EMAIL_KEY = "email";
     private static final String INVALID_TOKEN_MESSAGE = "INVALID_TOKEN";
 
     // 여기서 Base64는 충분히 안전합니다. 그 이유는:
@@ -51,6 +51,10 @@ public class JwtService {
 
     // 토큰 생성 및 저장
     public String createToken(JwtUserInfoDto member) {
+        Claims claims = Jwts.claims();
+        claims.put("email", member.getEmail()); // 이메일을 토큰에 삽입
+        claims.put("id", member.getId()); // user_id를 토큰에 삽입
+
         String accessToken = generateAccessToken(member);
         String refreshToken = generateRefreshToken(member);
         saveToRedis(accessToken, refreshToken); // Redis 저장
@@ -60,8 +64,9 @@ public class JwtService {
     // 토큰 만료 시간을 외부에서 지정하는 경우 사용
     public String createToken(JwtUserInfoDto member, Instant expiredTime) {
         Claims claims = Jwts.claims();
-        claims.put(EMAIL_KEY, member.getEmail());
-        Date expires = Date.from(expiredTime);
+        claims.put("email", member.getEmail()); // 이메일을 토큰에 삽입
+        claims.put("id", member.getId()); // user_id를 토큰에 삽입
+        Date expires = Date.from(expiredTime); //
 
         return makeToken(key, claims, expires);
     }
@@ -79,7 +84,8 @@ public class JwtService {
     // Claims 객체는 토큰에 정보들을 담는 객체라고 한다
     private String generateAccessToken(JwtUserInfoDto member) {
         Claims claims = Jwts.claims();
-        claims.put(EMAIL_KEY, member.getEmail());
+        claims.put("email", member.getEmail()); // 토큰에 이메일 삽입
+        claims.put("id", member.getId()); // 토큰에 id 삽입
 
         long now = (new Date()).getTime();
         Date expires = new Date(now + accessTokenExpireTime);
@@ -90,7 +96,9 @@ public class JwtService {
     // RefreshToken도 Claims에 이메일을 담아서 생성
     private String generateRefreshToken(JwtUserInfoDto member) {
         Claims claims = Jwts.claims();
-        claims.put(EMAIL_KEY, member.getEmail());
+        claims.put("email", member.getEmail()); // 토큰에 이메일 삽입
+        claims.put("id", member.getId()); // 토큰에 id 삽입
+
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime expires = now.plusSeconds(refreshTokenExpireTime);
         return makeToken(refreshKey, claims, Date.from(now.toInstant()), Date.from(expires.toInstant()));
@@ -117,12 +125,12 @@ public class JwtService {
     }
 
     public String getUserEmail() {
-        return getUserInfo(EMAIL_KEY);
+        return getUserInfo("email");
     }
 
     public String getUserEmail(String accessToken) {
         return parseClaims(accessToken)
-                .get(EMAIL_KEY, String.class);
+                .get("email", String.class);
     }
 
     private String getUserInfo(String needKey) {
@@ -131,7 +139,7 @@ public class JwtService {
             userDetails = (UserDetails) authentication.getPrincipal();
             return switch (needKey) {
                 // UserDetails 인터페이스에서는 getUsername()이 실제로 이메일을 반환함
-                case EMAIL_KEY -> userDetails.getUsername();
+                case "email" -> userDetails.getUsername();
                 default -> throw new NotFoundUserException("유저 정보를 찾을 수 없습니다.");
             };
         }

--- a/src/main/java/programo/_pro/service/MyPageService.java
+++ b/src/main/java/programo/_pro/service/MyPageService.java
@@ -53,4 +53,15 @@ public class MyPageService {
         // 해당 유저의 정보 업데이트
         userRepository.save(user);
     }
+
+    public void deleteUser(int userId) {
+        // 정보를 수정할 유저 객체 가져옴
+        User user = userRepository.findById((long) userId).orElseThrow(NotFoundUserException::byId);
+
+        // 회원 정보 비활성화 상태로 변경
+        user.setActive(false);
+
+        // 변경된 상태 업데이트
+        userRepository.save(user);
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 번호  -->

- Closes #34 
- Closes #60 

## 🛠️ PR 유형
<!-- 어떤 변경 사항이 있나요? -->
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 작업 내용
- 회원 탈퇴 기능 구현
- User의 isActive 값을 false로 변경하여 회원탈퇴 처리
- isActive의 값이 false인 사용자는 해당 이메일로 로그인 시도 시 "탈퇴한 계정이거나 존재하지 않습니다" 메시지 출력


## ✅ 변경 사항
유림님 피드백 변경사항) @yoorym-kim 

- 기존에는 로그인 성공 시 userId를 수동으로 삽입
- 이후 모든 요청에서 userId를 사용 가능
- 인증 시스템 전반적으로 userId를 인식할 수 있는 구조로 변경

![Image](https://github.com/user-attachments/assets/fb59f945-6842-489e-a319-585b3fba2b2e)

임의의 사용자 회원가입 후 그 사용자로 로그인 시 위와 같이 토큰 정보를 응답
``
eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImVoZGduc3RsYUBuYXZlci5jb20iLCJpZCI6MiwiZXhwIjoxNzQ1MjQ3NTk1fQ.jrNcIzCFvo9o6XK8JWJAd9aj6uJ2mVY4iLzOMktFe68
``
디코딩 시 
``
{
  "email": "ehdgnstla@naver.com",
  "id": 2,
  "exp": 1745247595
}
``
위와 같이 user_id값이 삽입

## 📸 스크린샷 (선택)

## 💬 코멘트

- 추후에 스케쥴링? 을 추가하여 일정 기간의 유효기간 컬럼을 테이블에 추가하여 테이블에서 자동삭제 기능을 구현할 예정 