### PR TITLE
Feature/history 로그인시 응답 객체 수정, 히스토리 페이지 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,11 +60,12 @@ dependencies {
 	// email verification
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
 
-	// Spring boot 3.0 querydsl 설정
+	// QueryDsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	// Reactor Netty
 	implementation 'io.projectreactor.netty:reactor-netty:1.1.15' // 또는 Spring Boot 3.4.x에 맞는 버전
 
@@ -80,20 +81,13 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
-// Querydsl 설정부
-def generated = 'src/main/generated'
+// QueryDsl
+def querydslSrcDir = 'src/main/generated'
 
-// querydsl QClass 파일 생성 위치를 지정
-tasks.withType(JavaCompile) {
-	options.getGeneratedSourceOutputDirectory().set(file(generated))
-}
-
-// java source set 에 querydsl QClass 위치 추가
-sourceSets {
-	main.java.srcDirs += [ generated ]
-}
-
-// gradle clean 시에 QClass 디렉토리 삭제
 clean {
-	delete file(generated)
+	delete file(querydslSrcDir)
+}
+
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }

--- a/src/main/java/programo/_pro/config/QueryDslConfig.java
+++ b/src/main/java/programo/_pro/config/QueryDslConfig.java
@@ -1,0 +1,14 @@
+package programo._pro.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/programo/_pro/config/security/SecurityConfig.java
+++ b/src/main/java/programo/_pro/config/security/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import programo._pro.global.filter.JwtAuthFilter;
 import programo._pro.global.filter.JwtAuthenticationFilter;
+import programo._pro.repository.TeamMemberRepository;
 import programo._pro.repository.UserRepository;
 import programo._pro.service.CustomUserDetailsService;
 import programo._pro.service.JwtService;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     private final CustomUserDetailsService customUserDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final TeamMemberRepository teamMemberRepository;
     private final UserRepository userRepository;
 
     //   사용자 인증을 처리하는 핵심 매니저 객체를 꺼내서 Bean으로 등록하는 함수
@@ -44,7 +46,7 @@ public class SecurityConfig {
     //    클라이언트가 로그인 요청을 보냈을 때, 아이디/비밀번호를 인증하고 JWT를 생성하는 필터
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter(HttpSecurity http) throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, userRepository);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, userRepository, teamMemberRepository);
         filter.setAuthenticationManager(authenticationManager(http));
         return filter;
     }
@@ -71,7 +73,7 @@ public class SecurityConfig {
                         // 개발환경에서는 모든 요청 허용 -> 추후 운영서버는 수정
                         .anyRequest().permitAll()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtService, userRepository), UsernamePasswordAuthenticationFilter.class) // JWT 검증 필터 삽입
+                .addFilterBefore(new JwtAuthenticationFilter(jwtService, userRepository, teamMemberRepository), UsernamePasswordAuthenticationFilter.class) // JWT 검증 필터 삽입
                 .addFilterAfter(new JwtAuthFilter(customUserDetailsService, jwtService), UsernamePasswordAuthenticationFilter.class) // JWT 검증 필터 삽입
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint));
         return http.build();

--- a/src/main/java/programo/_pro/controller/HistoryController.java
+++ b/src/main/java/programo/_pro/controller/HistoryController.java
@@ -1,26 +1,63 @@
-//package programo._pro.controller;
+package programo._pro.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.websocket.server.PathParam;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.*;
+import programo._pro.dto.codeDto.CodeRequestDto;
+import programo._pro.entity.Code;
+import programo._pro.entity.Problem;
+import programo._pro.global.ApiResponse;
+import programo._pro.repository.CodeRepository;
+import programo._pro.service.CodeService;
+import programo._pro.service.HistoryService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@RestController
+@RequestMapping("/api/history")
+@Slf4j
+@RequiredArgsConstructor
+@Tag(name = "히스토리 페이지", description = "히스토리 페이지 API")
+public class HistoryController {
+    private final HistoryService historyService;
+    private final CodeService codeService;
+
+    // test이벤트 id 값으로 문제 정보와 문제 정보 리스트를 조회 (UI 상 왼쪽 화면 첫 세팅 API)
+    @GetMapping("/gethistory")
+    public ResponseEntity<ApiResponse<List<Problem>>> getHistory(@PathParam("testId") int testId) {
+        List<Problem> history = historyService.getHistory(testId);
+
+        return ResponseEntity.ok(ApiResponse.success(history, "성공"));
+    }
+
+
+//     팀원 코드 클릭 시 첫번째 팀원의 문제풀이를 조회
+    // test_id 와 problem_id를 받아야함
+    @PostMapping("/first-member/code")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getFirstMemberCode(@RequestBody CodeRequestDto CodeRequestDto) {
+        Map<String, Object> data =  codeService.getFirstMemberCode(CodeRequestDto.getTest_id(), CodeRequestDto.getProblem_id());
+
+        return ResponseEntity.ok(ApiResponse.success(data));
+    }
+
+    // 문제 번호로 해당 문제의 정보를 조회합니다
+//    @GetMapping("/getproblem")
+//    public ResponseEntity<ApiResponse<Problem>> getProblem(@PathParam("problemId") int problemId) {
+//        Problem problem = historyService.getProblem(problemId);
 //
-//import io.swagger.v3.oas.annotations.tags.Tag;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.PathVariable;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//import programo._pro.global.ApiResponse;
-//import programo._pro.service.HistoryService;
+//        return ResponseEntity.ok(ApiResponse.success(problem, "문제 정보를 성공적으로 조회했습니다"));
 //
-//@RestController
-//@RequestMapping("/api/history")
-//@Slf4j
-//@RequiredArgsConstructor
-//@Tag(name = "히스토리 페이지", description = "히스토리 페이지 API")
-//public class HistoryController {
-//    private final HistoryService historyService;
-//
-//    @GetMapping("/{testId}")
-//    public ResponseEntity<ApiResponse<String>> getHistory(@PathVariable String testId) {
-//        historyService.getHistory(testId);
 //    }
-//}
+
+//    // 팀원의 제출한 코드를 조회
+//    @GetMapping("/getSubmitCode")
+//    public ResponseEntity<ApiResponse<String>> getSubmitCode(@PathParam("submitCode") String submitCode) {
+//
+//    }
+}

--- a/src/main/java/programo/_pro/controller/HistoryController.java
+++ b/src/main/java/programo/_pro/controller/HistoryController.java
@@ -5,19 +5,15 @@ import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.annotation.*;
 import programo._pro.dto.codeDto.CodeRequestDto;
-import programo._pro.entity.Code;
 import programo._pro.entity.Problem;
 import programo._pro.global.ApiResponse;
-import programo._pro.repository.CodeRepository;
 import programo._pro.service.CodeService;
 import programo._pro.service.HistoryService;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 @RestController
 @RequestMapping("/api/history")
@@ -37,27 +33,12 @@ public class HistoryController {
     }
 
 
-//     팀원 코드 클릭 시 첫번째 팀원의 문제풀이를 조회
-    // test_id 와 problem_id를 받아야함
-    @PostMapping("/first-member/code")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> getFirstMemberCode(@RequestBody CodeRequestDto CodeRequestDto) {
-        Map<String, Object> data =  codeService.getFirstMemberCode(CodeRequestDto.getTest_id(), CodeRequestDto.getProblem_id());
+    // 팀원의 문제 풀이 정보와 하이라이트 테이블을 조회
+//     test_id 와 problem_id, user_id를 받아야함
+    @PostMapping("/member/code")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getCodeMemberCodeAndHighlight(@RequestBody CodeRequestDto CodeRequestDto) {
+        Map<String, Object> data =  codeService.getCodeMemberCodeAndHighlight(CodeRequestDto.getTest_id(), CodeRequestDto.getProblem_id(), CodeRequestDto.getUser_id());
 
         return ResponseEntity.ok(ApiResponse.success(data));
     }
-
-    // 문제 번호로 해당 문제의 정보를 조회합니다
-//    @GetMapping("/getproblem")
-//    public ResponseEntity<ApiResponse<Problem>> getProblem(@PathParam("problemId") int problemId) {
-//        Problem problem = historyService.getProblem(problemId);
-//
-//        return ResponseEntity.ok(ApiResponse.success(problem, "문제 정보를 성공적으로 조회했습니다"));
-//
-//    }
-
-//    // 팀원의 제출한 코드를 조회
-//    @GetMapping("/getSubmitCode")
-//    public ResponseEntity<ApiResponse<String>> getSubmitCode(@PathParam("submitCode") String submitCode) {
-//
-//    }
 }

--- a/src/main/java/programo/_pro/dto/codeDto/CodeRequestDto.java
+++ b/src/main/java/programo/_pro/dto/codeDto/CodeRequestDto.java
@@ -1,0 +1,13 @@
+package programo._pro.dto.codeDto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class CodeRequestDto {
+    private int test_id;
+    private int problem_id;
+}

--- a/src/main/java/programo/_pro/dto/codeDto/CodeRequestDto.java
+++ b/src/main/java/programo/_pro/dto/codeDto/CodeRequestDto.java
@@ -10,4 +10,5 @@ import lombok.Setter;
 public class CodeRequestDto {
     private int test_id;
     private int problem_id;
+    private int user_id;
 }

--- a/src/main/java/programo/_pro/dto/codeDto/CodeResponseDto.java
+++ b/src/main/java/programo/_pro/dto/codeDto/CodeResponseDto.java
@@ -19,17 +19,8 @@ import java.time.LocalDateTime;
 @Getter
 public class CodeResponseDto {
 
-    @Column(name = "language", nullable = false)
     private String language;
-
-    @Column(name = "submit_code")
     private String submitCode;
-
-    @Column(name = "submit_at")
     private LocalDateTime submitAt;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    @Schema(description = "응시자 상태", example = "IN_PROGRESS, COMPLETED, ABSENT")
     private Status status;
 }

--- a/src/main/java/programo/_pro/dto/codeDto/CodeResponseDto.java
+++ b/src/main/java/programo/_pro/dto/codeDto/CodeResponseDto.java
@@ -1,0 +1,35 @@
+package programo._pro.dto.codeDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import programo._pro.entity.Problem;
+import programo._pro.entity.Status;
+import programo._pro.entity.Test;
+import programo._pro.entity.User;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@Setter
+@Getter
+public class CodeResponseDto {
+
+    @Column(name = "language", nullable = false)
+    private String language;
+
+    @Column(name = "submit_code")
+    private String submitCode;
+
+    @Column(name = "submit_at")
+    private LocalDateTime submitAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Schema(description = "응시자 상태", example = "IN_PROGRESS, COMPLETED, ABSENT")
+    private Status status;
+}

--- a/src/main/java/programo/_pro/dto/highlightDto/CodeHighlightResponseDto.java
+++ b/src/main/java/programo/_pro/dto/highlightDto/CodeHighlightResponseDto.java
@@ -1,0 +1,15 @@
+package programo._pro.dto.highlightDto;
+
+import lombok.*;
+import programo._pro.entity.Color;
+
+@Setter
+@Getter
+@Builder
+public class CodeHighlightResponseDto {
+    private String startPosition;
+    private String endPosition;
+    private Color color;
+    private String memo;
+    private boolean isActive;
+}

--- a/src/main/java/programo/_pro/dto/problemDto/ProblemDto.java
+++ b/src/main/java/programo/_pro/dto/problemDto/ProblemDto.java
@@ -1,0 +1,10 @@
+package programo._pro.dto.problemDto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProblemDto {
+    private int problemId;
+}

--- a/src/main/java/programo/_pro/entity/Code.java
+++ b/src/main/java/programo/_pro/entity/Code.java
@@ -5,8 +5,10 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Table(name = "code")
 @Entity
@@ -27,10 +29,13 @@ public class Code {
     @JoinColumn(name = "problem_id", nullable = false)
     private Problem problem;
 
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "code", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ToString.Exclude
+    private List<CodeHighight> codeHighlight;
 
     @Column(name = "language", nullable = false)
     private String language;

--- a/src/main/java/programo/_pro/entity/Code.java
+++ b/src/main/java/programo/_pro/entity/Code.java
@@ -1,34 +1,48 @@
-//package programo._pro.entity;
-//
-//import jakarta.persistence.*;
-//import lombok.AllArgsConstructor;
-//import lombok.Data;
-//import lombok.NoArgsConstructor;
-//
-//@Table(name = "code")
-//@Entity
-//@AllArgsConstructor
-//@NoArgsConstructor
-//@Data
-//public class Code {
-//
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
-//    private long id;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @Column(name = "test_id", nullable = false)
-//    private Test test;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @Column(name = "problem_id", nullable = false)
-//    private Problem problem;
-//
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @Column(name = "user_id", nullable = false)
-//    private User user;
-//
-//
-//
-//}
+package programo._pro.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "code")
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class Code {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "test_id", nullable = false)
+    private Test test;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "language", nullable = false)
+    private String language;
+
+    @Column(name = "submit_code")
+    private String submitCode;
+
+    @Column(name = "submit_at")
+    private LocalDateTime submitAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Schema(description = "응시자 상태", example = "IN_PROGRESS, COMPLETED, ABSENT")
+    private Status status;
+}

--- a/src/main/java/programo/_pro/entity/Code.java
+++ b/src/main/java/programo/_pro/entity/Code.java
@@ -1,0 +1,34 @@
+//package programo._pro.entity;
+//
+//import jakarta.persistence.*;
+//import lombok.AllArgsConstructor;
+//import lombok.Data;
+//import lombok.NoArgsConstructor;
+//
+//@Table(name = "code")
+//@Entity
+//@AllArgsConstructor
+//@NoArgsConstructor
+//@Data
+//public class Code {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private long id;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @Column(name = "test_id", nullable = false)
+//    private Test test;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @Column(name = "problem_id", nullable = false)
+//    private Problem problem;
+//
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @Column(name = "user_id", nullable = false)
+//    private User user;
+//
+//
+//
+//}

--- a/src/main/java/programo/_pro/entity/CodeHighight.java
+++ b/src/main/java/programo/_pro/entity/CodeHighight.java
@@ -1,0 +1,44 @@
+package programo._pro.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "code_highlight")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CodeHighight {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "code_id", nullable = false)
+    private Code code;
+
+    @Column(name = "start_pos")
+    private String startPosition;
+
+    @Column(name = "end_pos")
+    private String endPosition;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "color")
+    private Color color;
+
+    @Column(name = "memo")
+    private String memo;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive = false;
+}

--- a/src/main/java/programo/_pro/entity/Color.java
+++ b/src/main/java/programo/_pro/entity/Color.java
@@ -1,0 +1,8 @@
+package programo._pro.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(implementation = Color.class)
+public enum Color {
+    RED, YELLOW, GREEN, BLUE, PINK, ORANGE
+}

--- a/src/main/java/programo/_pro/entity/EmailVerification.java
+++ b/src/main/java/programo/_pro/entity/EmailVerification.java
@@ -33,6 +33,7 @@ public class EmailVerification {
     private LocalDateTime expiredAt;
 
     @Column(name = "is_verified", nullable = false)
+    @Builder.Default
     private boolean isVerified = false;
 
 

--- a/src/main/java/programo/_pro/entity/PasswordToken.java
+++ b/src/main/java/programo/_pro/entity/PasswordToken.java
@@ -36,6 +36,7 @@ public class PasswordToken {
     private LocalDateTime expiredAt;
 
     @Column(name = "is_used", nullable = false)
+    @Builder.Default
     private boolean isUsed = false ;
 
 

--- a/src/main/java/programo/_pro/entity/Problem.java
+++ b/src/main/java/programo/_pro/entity/Problem.java
@@ -1,0 +1,55 @@
+package programo._pro.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Table(name = "problem")
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class Problem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "문제 id", example = "20")
+    private long id;
+
+    @Column(name = "baek_num", nullable = false)
+    @Schema(description = "해당 id의 백준문제번호", example = "3044")
+    private int baekNum;
+
+
+    @Column(name = "title", nullable = false)
+    @Schema(description = "문제 이름", example = "A+B 문제")
+    private String title;
+
+    @Column(name = "description", nullable = false)
+    @Schema(description = "문제 설명", example = "A+B를 구하시오")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "level", nullable = false)
+    @Schema(description = "문제의 난이도", example = "EASY, MEDIUM, HARD")
+    private Level level;
+
+    @Column(name = "ex_input", nullable = false)
+    @Schema(description = "예제 입력값")
+    private String exInput;
+
+    @Column(name = "ex_output", nullable = false)
+    @Schema(description = "예제 출력값")
+    private String exOutput;
+
+
+    @Column(name = "time_limit", nullable = false)
+    @Schema(description = "문제의 시간제한")
+    private int timeLimit;
+
+    @Column(name = "memory_limit", nullable = false)
+    @Schema(description = "문제의 메모리 제한")
+    private int memoryLimit;
+}

--- a/src/main/java/programo/_pro/entity/Problem.java
+++ b/src/main/java/programo/_pro/entity/Problem.java
@@ -44,6 +44,14 @@ public class Problem {
     @Schema(description = "예제 출력값")
     private String exOutput;
 
+    @Column(name = "input_des")
+    @Schema(description = "예제 입력값 설명")
+    private String inputDes;
+
+    @Column(name = "output_des")
+    @Schema(description = "예제 입력값 설명")
+    private String outputDes;
+
 
     @Column(name = "time_limit", nullable = false)
     @Schema(description = "문제의 시간제한")

--- a/src/main/java/programo/_pro/entity/Status.java
+++ b/src/main/java/programo/_pro/entity/Status.java
@@ -1,0 +1,8 @@
+package programo._pro.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(implementation = Status.class)
+public enum Status {
+    IN_PROGRESS, COMPLETED, ABSENT
+}

--- a/src/main/java/programo/_pro/entity/Test.java
+++ b/src/main/java/programo/_pro/entity/Test.java
@@ -1,0 +1,41 @@
+package programo._pro.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "test")
+public class Test {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "테스트 ID", example = "101")
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false, unique = true)
+    @Schema(description = "테스트의 TeamID", example = "2")
+    private Team team;
+
+    @Column(name = "created_at", nullable = false)
+    @Schema(description = "테스트 생성시각", example = "2025-04-21T10:15:30+09:00[Asia/Seoul]")
+    private ZonedDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")); // 테스트 생성 날짜 저장
+    }
+}

--- a/src/main/java/programo/_pro/entity/TestProblem.java
+++ b/src/main/java/programo/_pro/entity/TestProblem.java
@@ -1,0 +1,30 @@
+package programo._pro.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Fetch;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "test_problem")
+@Entity
+@Data
+public class TestProblem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "test_id")
+    private Test test;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id")
+    private Problem problem;
+}

--- a/src/main/java/programo/_pro/entity/User.java
+++ b/src/main/java/programo/_pro/entity/User.java
@@ -34,5 +34,6 @@ public class User {
     private String password;
 
     @Column(name = "is_active", nullable = false)
+    @Builder.Default
     private boolean isActive = true;
 }

--- a/src/main/java/programo/_pro/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/programo/_pro/global/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import programo._pro.global.ApiResponse;
 import programo._pro.global.exception.chatException.NotFoundChatException;
+import programo._pro.global.exception.codeException.CodeException;
 import programo._pro.global.exception.highlightException.HighlightException;
 import programo._pro.global.exception.problemException.ProblemException;
 import programo._pro.global.exception.testException.TestException;
@@ -115,6 +116,7 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    // 테스트 이벤트 관련 예외
     @ExceptionHandler(TestException.class)
     public ResponseEntity<ApiResponse<?>> handleTestException(TestException ex) {
         ApiResponse<?> response = ApiResponse.fail(ex.getMessage());
@@ -122,8 +124,17 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    // 하이라이트 테이블 관련 예외
     @ExceptionHandler(HighlightException.class)
     public ResponseEntity<ApiResponse<?>> handleHighlightException(HighlightException ex) {
+        ApiResponse<?> response = ApiResponse.fail(ex.getMessage());
+        log.error(ex.getMessage(), ex);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // 제출 코드 관련 예외
+    @ExceptionHandler(CodeException.class)
+    public ResponseEntity<ApiResponse<?>> handleCodeException(CodeException ex) {
         ApiResponse<?> response = ApiResponse.fail(ex.getMessage());
         log.error(ex.getMessage(), ex);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/programo/_pro/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/programo/_pro/global/exception/GlobalExceptionHandler.java
@@ -12,6 +12,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import programo._pro.global.ApiResponse;
 import programo._pro.global.exception.chatException.NotFoundChatException;
+import programo._pro.global.exception.highlightException.HighlightException;
+import programo._pro.global.exception.problemException.ProblemException;
+import programo._pro.global.exception.testException.TestException;
 import programo._pro.global.exception.userException.UserException;
 
 @Slf4j
@@ -104,5 +107,25 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 
+    // 문제 관련 예외 처리
+    @ExceptionHandler(ProblemException.class)
+    public ResponseEntity<ApiResponse<?>> handleProblemException(ProblemException ex) {
+        ApiResponse<?> response = ApiResponse.fail(ex.getMessage());
+        log.error(ex.getMessage(), ex);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 
+    @ExceptionHandler(TestException.class)
+    public ResponseEntity<ApiResponse<?>> handleTestException(TestException ex) {
+        ApiResponse<?> response = ApiResponse.fail(ex.getMessage());
+        log.error(ex.getMessage(), ex);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(HighlightException.class)
+    public ResponseEntity<ApiResponse<?>> handleHighlightException(HighlightException ex) {
+        ApiResponse<?> response = ApiResponse.fail(ex.getMessage());
+        log.error(ex.getMessage(), ex);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 }

--- a/src/main/java/programo/_pro/global/exception/codeException/CodeException.java
+++ b/src/main/java/programo/_pro/global/exception/codeException/CodeException.java
@@ -1,0 +1,15 @@
+package programo._pro.global.exception.codeException;
+
+public class CodeException extends RuntimeException {
+    public CodeException(String message) {
+        super(message);
+    }
+
+    public static CodeException NotFoundCodeException() {
+      return new CodeException("풀이를 조회할 수 없습니다");
+    }
+    public static CodeException NotFoundCodeHighlightException() {
+        return new CodeException("하이라이트 정보를 가져올 수 없습니다.");
+
+    }
+}

--- a/src/main/java/programo/_pro/global/exception/highlightException/HighlightException.java
+++ b/src/main/java/programo/_pro/global/exception/highlightException/HighlightException.java
@@ -1,0 +1,11 @@
+package programo._pro.global.exception.highlightException;
+
+public class HighlightException extends RuntimeException {
+    public HighlightException(String message) {
+        super(message);
+    }
+
+    public static HighlightException NotFoundHighlightException() {
+        return new HighlightException("이 코드의 하이라이트를 찾을 수 없습니다");
+    }
+}

--- a/src/main/java/programo/_pro/global/exception/problemException/ProblemException.java
+++ b/src/main/java/programo/_pro/global/exception/problemException/ProblemException.java
@@ -1,0 +1,11 @@
+package programo._pro.global.exception.problemException;
+
+public class ProblemException extends RuntimeException {
+    public ProblemException(String message) {
+        super(message);
+    }
+
+    public static ProblemException NotFoundProblemException() {
+        return new ProblemException("문제를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/programo/_pro/global/exception/testException/TestException.java
+++ b/src/main/java/programo/_pro/global/exception/testException/TestException.java
@@ -1,0 +1,11 @@
+package programo._pro.global.exception.testException;
+
+public class TestException extends RuntimeException {
+    public TestException(String message) {
+        super(message);
+    }
+
+    public static TestException NotFoundTestException(String testId) {
+        return new TestException("테스트를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/programo/_pro/repository/CodeHighlightRepository.java
+++ b/src/main/java/programo/_pro/repository/CodeHighlightRepository.java
@@ -1,0 +1,10 @@
+package programo._pro.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import programo._pro.entity.CodeHighight;
+
+import java.util.List;
+
+public interface CodeHighlightRepository extends JpaRepository<CodeHighight, Long> {
+//    List<CodeHighight> findByProblemId(long firstProblemId);
+}

--- a/src/main/java/programo/_pro/repository/CodeQueryRepository.java
+++ b/src/main/java/programo/_pro/repository/CodeQueryRepository.java
@@ -4,7 +4,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import programo._pro.entity.Code;
+import programo._pro.entity.CodeHighight;
 import programo._pro.entity.QCode;
+import programo._pro.entity.QCodeHighight;
 
 import java.util.List;
 
@@ -13,19 +15,31 @@ import java.util.List;
 public class CodeQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
-
-    // test_id와 problem_id로 해당 problem_id 의 유저들의 풀이 리스트를 조회
-    public List<Code> findCodeByTestIdAndProblemId(long testId, long problemId) {
+    public List<Code> findCodeByTestIdAndProblemIdAndUserId(int testId, int problemId, int userId) {
         QCode qCode = QCode.code;
+//        QCodeHighight qHighlight = QCodeHighight.codeHighight;
 
-
-        List<Code> codes = jpaQueryFactory
-                .selectFrom(qCode) // Code 테이블에서 모든 컬럼을 가져온다
-                .where(qCode.id.eq(testId) // Code 테이블의 test_id 가 일치할 때
-                        .and(qCode.problem.id.eq(problemId))) // Code 테이블의 problem_id가 일치할 때
+        return jpaQueryFactory
+                .selectFrom(qCode)
+//                .leftJoin(qCode.codeHighlight, qHighlight).fetchJoin() // ✅ 연관관계 명확히 하고 fetchJoin
+                .where(
+                        qCode.test.id.eq((long) testId),
+                        qCode.problem.id.eq((long) problemId),
+                        qCode.user.id.eq((long) userId)
+                )
                 .fetch();
-
-        return codes;
     }
 
+    public List<CodeHighight> findHighlightByCodeIdAndUserId(int codeId, int userId) {
+        QCodeHighight qHighlight = QCodeHighight.codeHighight;
+
+        return jpaQueryFactory
+                .selectFrom(qHighlight)
+                .where(
+                        qHighlight.user.id.eq((long) userId),
+                        qHighlight.code.id.eq((long) codeId)
+                )
+                .fetch();
+
+    }
 }

--- a/src/main/java/programo/_pro/repository/CodeQueryRepository.java
+++ b/src/main/java/programo/_pro/repository/CodeQueryRepository.java
@@ -1,0 +1,31 @@
+package programo._pro.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import programo._pro.entity.Code;
+import programo._pro.entity.QCode;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CodeQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    // test_id와 problem_id로 해당 problem_id 의 유저들의 풀이 리스트를 조회
+    public List<Code> findCodeByTestIdAndProblemId(long testId, long problemId) {
+        QCode qCode = QCode.code;
+
+
+        List<Code> codes = jpaQueryFactory
+                .selectFrom(qCode) // Code 테이블에서 모든 컬럼을 가져온다
+                .where(qCode.id.eq(testId) // Code 테이블의 test_id 가 일치할 때
+                        .and(qCode.problem.id.eq(problemId))) // Code 테이블의 problem_id가 일치할 때
+                .fetch();
+
+        return codes;
+    }
+
+}

--- a/src/main/java/programo/_pro/repository/CodeRepository.java
+++ b/src/main/java/programo/_pro/repository/CodeRepository.java
@@ -1,0 +1,7 @@
+package programo._pro.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import programo._pro.entity.Code;
+
+public interface CodeRepository extends JpaRepository<Code, Long> {
+}

--- a/src/main/java/programo/_pro/repository/ProblemRepository.java
+++ b/src/main/java/programo/_pro/repository/ProblemRepository.java
@@ -1,0 +1,7 @@
+package programo._pro.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import programo._pro.entity.Problem;
+
+public interface ProblemRepository extends JpaRepository<Problem, Integer> {
+}

--- a/src/main/java/programo/_pro/repository/TestProblemQueryRepository.java
+++ b/src/main/java/programo/_pro/repository/TestProblemQueryRepository.java
@@ -1,0 +1,29 @@
+package programo._pro.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import programo._pro.entity.Problem;
+import programo._pro.entity.QProblem;
+import programo._pro.entity.QTestProblem;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@Repository
+public class TestProblemQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Problem> findProblemsByTestId(long testId) {
+        QTestProblem testProblem = QTestProblem.testProblem;
+        QProblem problem = QProblem.problem;
+
+        return jpaQueryFactory
+                .select(testProblem.problem)
+                .from(testProblem)
+                .join(testProblem.problem, problem)
+                .where(testProblem.test.id.eq(testId))
+                .fetch();
+    }
+}

--- a/src/main/java/programo/_pro/repository/TestProblemRepository.java
+++ b/src/main/java/programo/_pro/repository/TestProblemRepository.java
@@ -1,0 +1,11 @@
+package programo._pro.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import programo._pro.entity.TestProblem;
+
+import java.util.List;
+
+public interface TestProblemRepository extends JpaRepository<TestProblem, Integer> {
+
+    List<TestProblem> findAllByTest_id(long testId);
+}

--- a/src/main/java/programo/_pro/repository/TestRepository.java
+++ b/src/main/java/programo/_pro/repository/TestRepository.java
@@ -1,0 +1,8 @@
+package programo._pro.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import programo._pro.entity.Test;
+
+public interface TestRepository extends JpaRepository<Test, Integer> {
+
+}

--- a/src/main/java/programo/_pro/service/CodeService.java
+++ b/src/main/java/programo/_pro/service/CodeService.java
@@ -3,20 +3,15 @@ package programo._pro.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import programo._pro.dto.codeDto.CodeRequestDto;
 import programo._pro.dto.codeDto.CodeResponseDto;
 import programo._pro.dto.highlightDto.CodeHighlightResponseDto;
 import programo._pro.entity.Code;
-import programo._pro.entity.CodeHighight;
 import programo._pro.global.exception.codeException.CodeException;
 import programo._pro.repository.CodeHighlightRepository;
 import programo._pro.repository.CodeQueryRepository;
 import programo._pro.repository.CodeRepository;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -28,31 +23,19 @@ public class CodeService {
 
 
     // 팀원의 첫번째 풀이와 하이라이트 정보를 조회
-    public Map<String, Object> getFirstMemberCode(int test_id, int problem_id) {
+    public Map<String, Object> getCodeMemberCodeAndHighlight(int test_id, int problem_id, int user_id) {
         // 풀이와 하이라이트 정보를 함께 담을 데이터 포맷
         Map<String, Object> data = new HashMap<>();
 
+        // 하이라이트 리스트
+        List<CodeHighlightResponseDto> highlightResponseDtos = new ArrayList<>();
+
+
         // 팀원의 풀이를 가져오기
-        List<Code> codeList = codeQueryRepository.findCodeByTestIdAndProblemId(test_id, problem_id);
+        List<Code> codeList = codeQueryRepository.findCodeByTestIdAndProblemIdAndUserId(test_id, problem_id, user_id);
 
-        // 팀원의 풀이 리스트 확인
-        log.info(codeList.toString());
-
-        // 팀원의 풀이 중 첫번 째 코드 조회
+        // 코드 정보와 하이라이트 테이블이 담긴 정보 1개 조회
         Code first = codeList.stream().findFirst().orElseThrow(CodeException::NotFoundCodeException);
-
-        // 해당 풀이의 하이라이트 정보 조회
-        CodeHighight codeHighight = codeHighlightRepository.findById(first.getId())
-                .orElseThrow(CodeException::NotFoundCodeHighlightException);
-
-        // CodeHighlight 응답 객체 생성
-        CodeHighlightResponseDto codeHighlightResponseDto = CodeHighlightResponseDto.builder()
-                .startPosition(codeHighight.getStartPosition())
-                .endPosition(codeHighight.getEndPosition())
-                .color(codeHighight.getColor())
-                .memo(codeHighight.getMemo())
-                .isActive(codeHighight.isActive())
-                .build();
 
         // 제출한 풀이 응답객체 생성
         CodeResponseDto codeResponseDto = CodeResponseDto.builder()
@@ -62,9 +45,27 @@ public class CodeService {
                 .submitAt(first.getSubmitAt())
                 .build();
 
+
+        // 해당 풀이의 하이라이트 리스트 조회
+        codeQueryRepository.findHighlightByCodeIdAndUserId((int) first.getId(), user_id).forEach(
+                highlight -> {
+                    CodeHighlightResponseDto codeHighlightResponseDto = CodeHighlightResponseDto.builder()
+                            .startPosition(highlight.getStartPosition())
+                            .endPosition(highlight.getEndPosition())
+                            .color(highlight.getColor())
+                            .memo(highlight.getMemo())
+                            .isActive(highlight.isActive())
+                            .build();
+
+                    // 매 순회마다 리스트에 추가
+                    highlightResponseDtos.add(codeHighlightResponseDto);
+                }
+        );
+
+
         // Json 추가
         data.put("code", codeResponseDto);
-        data.put("highlight", codeHighlightResponseDto);
+        data.put("highlights", highlightResponseDtos);
 
         return data;
     }

--- a/src/main/java/programo/_pro/service/CodeService.java
+++ b/src/main/java/programo/_pro/service/CodeService.java
@@ -1,0 +1,71 @@
+package programo._pro.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import programo._pro.dto.codeDto.CodeRequestDto;
+import programo._pro.dto.codeDto.CodeResponseDto;
+import programo._pro.dto.highlightDto.CodeHighlightResponseDto;
+import programo._pro.entity.Code;
+import programo._pro.entity.CodeHighight;
+import programo._pro.global.exception.codeException.CodeException;
+import programo._pro.repository.CodeHighlightRepository;
+import programo._pro.repository.CodeQueryRepository;
+import programo._pro.repository.CodeRepository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CodeService {
+    private final CodeRepository codeRepository;
+    private final CodeQueryRepository codeQueryRepository;
+    private final CodeHighlightRepository codeHighlightRepository;
+
+
+    // 팀원의 첫번째 풀이와 하이라이트 정보를 조회
+    public Map<String, Object> getFirstMemberCode(int test_id, int problem_id) {
+        // 풀이와 하이라이트 정보를 함께 담을 데이터 포맷
+        Map<String, Object> data = new HashMap<>();
+
+        // 팀원의 풀이를 가져오기
+        List<Code> codeList = codeQueryRepository.findCodeByTestIdAndProblemId(test_id, problem_id);
+
+        // 팀원의 풀이 리스트 확인
+        log.info(codeList.toString());
+
+        // 팀원의 풀이 중 첫번 째 코드 조회
+        Code first = codeList.stream().findFirst().orElseThrow(CodeException::NotFoundCodeException);
+
+        // 해당 풀이의 하이라이트 정보 조회
+        CodeHighight codeHighight = codeHighlightRepository.findById(first.getId())
+                .orElseThrow(CodeException::NotFoundCodeHighlightException);
+
+        // CodeHighlight 응답 객체 생성
+        CodeHighlightResponseDto codeHighlightResponseDto = CodeHighlightResponseDto.builder()
+                .startPosition(codeHighight.getStartPosition())
+                .endPosition(codeHighight.getEndPosition())
+                .color(codeHighight.getColor())
+                .memo(codeHighight.getMemo())
+                .isActive(codeHighight.isActive())
+                .build();
+
+        // 제출한 풀이 응답객체 생성
+        CodeResponseDto codeResponseDto = CodeResponseDto.builder()
+                .submitCode(first.getSubmitCode())
+                .language(first.getLanguage())
+                .status(first.getStatus())
+                .submitAt(first.getSubmitAt())
+                .build();
+
+        // Json 추가
+        data.put("code", codeResponseDto);
+        data.put("highlight", codeHighlightResponseDto);
+
+        return data;
+    }
+}

--- a/src/main/java/programo/_pro/service/HistoryService.java
+++ b/src/main/java/programo/_pro/service/HistoryService.java
@@ -5,6 +5,6 @@
 //@Service
 //public class HistoryService {
 //    public void getHistory(String testId) {
-//
+//        // testId 값을 받아오면,
 //    }
 //}

--- a/src/main/java/programo/_pro/service/HistoryService.java
+++ b/src/main/java/programo/_pro/service/HistoryService.java
@@ -1,10 +1,68 @@
-//package programo._pro.service;
+package programo._pro.service;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import programo._pro.dto.highlightDto.CodeHighlightResponseDto;
+import programo._pro.entity.CodeHighight;
+import programo._pro.entity.Problem;
+import programo._pro.global.exception.problemException.ProblemException;
+import programo._pro.repository.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class HistoryService {
+
+    private final TestRepository testRepository;
+    private final TeamRepository teamRepository;
+    private final TestProblemRepository testProblemRepository;
+    private final TestProblemQueryRepository problemQueryRepository;
+    private final ProblemRepository problemRepository;
+    private final CodeHighlightRepository codeHighlightRepository;
+
+
+    // 해당 test_id의 모든 문제 정보들을 조회합니다
+    @Transactional(readOnly = true)
+    public List<Problem> getHistory(int testId) {
+        Map<String, Object> data = new HashMap<>();
+
+        // 문제 정보 리스트
+//        List<Map<String, Object>> problemList = new java.util.ArrayList<>();
+
+        List<Problem> problems = problemQueryRepository.findProblemsByTestId(testId);
+
+        // 테스트 id로 조회한 문제들 리스트
+        log.info("problem List : {} ", problems.toString());
+
+        // 첫 번째 문제 정보 가져오기 (옵션)
+//        Problem firstProblem = problems.stream().findFirst()
+//                .orElseThrow(ProblemException::NotFoundProblemException);
+
+
+//        // 반복하며 각각의 문제 정보 추가
+//        for (Problem p : problems) {
+//            Map<String, Object> map = new HashMap<>();
+//            map.put("problem_id", p.getId());
+//            map.put("problem_baek_num", p.getBaekNum());
+//            problemList.add(map);
+//        }
+
+        // ✅ 최종 결과 구조
+//        data.put("problemList", problemList); // 여러 문제 정보
+//        data.put("problem", firstProblem);        // 첫 번째 문제 정보
+
+        return problems;
+    }
+
+    // 문제 번호로 문제 정보 조회
+//    public Problem getProblem(int problemId) {
 //
-//import org.springframework.stereotype.Service;
-//
-//@Service
-//public class HistoryService {
-//    public void getHistory(String testId) {
-//        // testId 값을 받아오면,
+//        return problemRepository.findById(problemId).orElseThrow(ProblemException::NotFoundProblemException);
 //    }
-//}
+}

--- a/src/main/resources/db/schema_dev.sql
+++ b/src/main/resources/db/schema_dev.sql
@@ -69,6 +69,8 @@ CREATE TABLE problem
     level ENUM('EASY', 'MEDIUM', 'HARD') NOT NULL,
     ex_input     TEXT,
     ex_output    TEXT,
+    input_des    TEXT,
+    output_des   TEXT,
     time_limit   INT,
     memory_limit INT
 );
@@ -257,7 +259,9 @@ INSERT INTO code_highlight (user_id, code_id, start_pos, end_pos, color, memo)
 VALUES
     (2, 1, '3:5', '10:20', 'BLUE', 'sub logic'),
     (1, 1, '1:1', '1:10', 'YELLOW', 'main logic'),
-    (2, 2, '2:5', '2:15', 'RED', 'bug here');
+    (2, 2, '2:5', '2:15', 'RED', 'bug here'),
+    (1, 1, '2:5', '2:15', 'RED', 'bug here'),
+    (1, 1, '2:5', '2:15', 'RED', 'bug here');
 
 
 -- ✅ chatbot

--- a/src/main/resources/db/schema_dev.sql
+++ b/src/main/resources/db/schema_dev.sql
@@ -121,7 +121,7 @@ CREATE TABLE code
     user_id      BIGINT NOT NULL,
     language     VARCHAR(50),
     submit_code  TEXT   NOT NULL,
-    submitted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    submit_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     status ENUM('IN_PROGRESS', 'COMPLETED', 'ABSENT') NOT NULL,
     FOREIGN KEY (test_id) REFERENCES test (id),
     FOREIGN KEY (problem_id) REFERENCES problem (id),
@@ -136,7 +136,7 @@ CREATE TABLE code_highlight
     code_id   BIGINT NOT NULL,
     start_pos TEXT   NOT NULL,
     end_pos   TEXT   NOT NULL,
-    color     ENUM('red', 'yellow', 'green', 'blue', 'pink', 'orange') DEFAULT 'yellow',
+    color     ENUM('RED', 'YELLOW', 'GREEN', 'BLUE', 'PINK', 'ORANGE') DEFAULT 'YELLOW',
     memo      TEXT,
     is_active BOOLEAN DEFAULT FALSE,
     FOREIGN KEY (code_id) REFERENCES code (id),
@@ -255,8 +255,10 @@ VALUES
 -- ✅ code_highlight
 INSERT INTO code_highlight (user_id, code_id, start_pos, end_pos, color, memo)
 VALUES
-    (1, 1, '1:1', '1:10', 'yellow', 'main logic'),
-    (2, 2, '2:5', '2:15', 'red', 'bug here');
+    (2, 1, '3:5', '10:20', 'BLUE', 'sub logic'),
+    (1, 1, '1:1', '1:10', 'YELLOW', 'main logic'),
+    (2, 2, '2:5', '2:15', 'RED', 'bug here');
+
 
 -- ✅ chatbot
 INSERT INTO chatbot (team_id, test_date, message)

--- a/src/main/resources/db/schema_dev.sql
+++ b/src/main/resources/db/schema_dev.sql
@@ -188,3 +188,97 @@ CREATE TABLE password_reset_token
 INSERT INTO mydb.user
 (id, email, user_name, password, created_at, is_active)
 VALUES(0, 'test123@example.com', 'test123', 'test123@!!', current_timestamp(), 1);
+
+-- 샘플 데이터 삽입
+-- ✅ user
+INSERT INTO user (email, user_name, password, is_active)
+VALUES
+    ('alice@example.com', 'Alice', 'pw1', TRUE),
+    ('bob@example.com', 'Bob', 'pw2', TRUE),
+    ('charlie@example.com', 'Charlie', 'pw3', TRUE);
+
+-- ✅ team
+INSERT INTO team (team_name, description, level, problem_count, start_time, duration_time, current_members, leader_id, is_active)
+VALUES
+    ('Team Alpha', 'First team', 'EASY', 2, NOW(), 60, 3, 1, TRUE),
+    ('Team Beta', 'Second team', 'MEDIUM', 3, NOW(), 90, 2, 2, TRUE);
+
+-- ✅ team_member
+INSERT INTO team_member (user_id, team_id, is_leader)
+VALUES
+    (1, 1, TRUE),
+    (2, 1, FALSE),
+    (3, 1, FALSE),
+    (2, 2, TRUE),
+    (3, 2, FALSE);
+
+-- ✅ problem
+INSERT INTO problem (baek_num, title, description, level, ex_input, ex_output, time_limit, memory_limit)
+VALUES
+    (1000, 'A + B', 'Add two numbers', 'EASY', '1 2', '3', 1, 128),
+    (1001, 'A - B', 'Subtract two numbers', 'EASY', '3 1', '2', 1, 128),
+    (1002, 'Multiply', 'Multiply numbers', 'MEDIUM', '2 3', '6', 2, 256);
+
+-- ✅ chatroom
+INSERT INTO chatroom (team_id)
+VALUES
+    (1), (2);
+
+-- ✅ message
+INSERT INTO message (chat_room_id, user_id, content)
+VALUES
+    (1, 1, 'Hello team!'),
+    (1, 2, 'Hi Alice!'),
+    (2, 2, 'Let’s start the test.');
+
+-- ✅ test
+INSERT INTO test (team_id)
+VALUES
+    (1),
+    (2);
+
+-- ✅ test_problem
+INSERT INTO test_problem (test_id, problem_id)
+VALUES
+    (1, 1),
+    (1, 2),
+    (2, 2),
+    (2, 3);
+
+-- ✅ code
+INSERT INTO code (test_id, problem_id, user_id, language, submit_code, status)
+VALUES
+    (1, 1, 1, 'Java', 'public class A {}', 'COMPLETED'),
+    (1, 2, 2, 'Python', 'print(1-2)', 'IN_PROGRESS'),
+    (2, 3, 3, 'C++', 'int main() {}', 'ABSENT');
+
+-- ✅ code_highlight
+INSERT INTO code_highlight (user_id, code_id, start_pos, end_pos, color, memo)
+VALUES
+    (1, 1, '1:1', '1:10', 'yellow', 'main logic'),
+    (2, 2, '2:5', '2:15', 'red', 'bug here');
+
+-- ✅ chatbot
+INSERT INTO chatbot (team_id, test_date, message)
+VALUES
+    (1, CURDATE(), 'Test will begin shortly'),
+    (2, CURDATE(), 'Reminder: test today');
+
+-- ✅ chatbot_problem
+INSERT INTO chatbot_problem (chatbot_id, problem_id)
+VALUES
+    (1, 1),
+    (1, 2),
+    (2, 3);
+
+-- ✅ email_verification
+INSERT INTO email_verification (email, code, expired_at)
+VALUES
+    ('alice@example.com', 123456, NOW() + INTERVAL 5 MINUTE),
+    ('bob@example.com', 654321, NOW() + INTERVAL 10 MINUTE);
+
+-- ✅ password_reset_token
+INSERT INTO password_reset_token (user_id, tempPassword)
+VALUES
+    (1, 'tempPw123!'),
+    (2, 'resetMe456!');

--- a/src/main/resources/db/schema_prod.sql
+++ b/src/main/resources/db/schema_prod.sql
@@ -69,6 +69,8 @@ CREATE TABLE problem
     level ENUM('EASY', 'MEDIUM', 'HARD') NOT NULL,
     ex_input     TEXT,
     ex_output    TEXT,
+    input_des    TEXT,
+    output_des   TEXT,
     time_limit   INT,
     memory_limit INT
 );
@@ -256,8 +258,11 @@ VALUES
 -- ✅ code_highlight
 INSERT INTO code_highlight (user_id, code_id, start_pos, end_pos, color, memo)
 VALUES
+    (2, 1, '3:5', '10:20', 'BLUE', 'sub logic'),
     (1, 1, '1:1', '1:10', 'YELLOW', 'main logic'),
-    (2, 2, '2:5', '2:15', 'RED', 'bug here');
+    (2, 2, '2:5', '2:15', 'RED', 'bug here'),
+    (1, 1, '2:5', '2:15', 'RED', 'bug here'),
+    (1, 1, '2:5', '2:15', 'RED', 'bug here');
 
 -- ✅ chatbot
 INSERT INTO chatbot (team_id, test_date, message)

--- a/src/main/resources/db/schema_prod.sql
+++ b/src/main/resources/db/schema_prod.sql
@@ -121,7 +121,7 @@ CREATE TABLE code
     user_id      BIGINT NOT NULL,
     language     VARCHAR(50),
     submit_code  TEXT   NOT NULL,
-    submitted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    submit_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     status ENUM('IN_PROGRESS', 'COMPLETED', 'ABSENT') NOT NULL,
     FOREIGN KEY (test_id) REFERENCES test (id),
     FOREIGN KEY (problem_id) REFERENCES problem (id),
@@ -136,7 +136,7 @@ CREATE TABLE code_highlight
     code_id   BIGINT NOT NULL,
     start_pos TEXT   NOT NULL,
     end_pos   TEXT   NOT NULL,
-    color     ENUM('red', 'yellow', 'green', 'blue', 'pink', 'orange') DEFAULT 'yellow',
+    color     ENUM('RED', 'YELLOW', 'GREEN', 'BLUE', 'PINK', 'ORANGE') DEFAULT 'YELLOW',
     memo      TEXT,
     is_active BOOLEAN DEFAULT FALSE,
     FOREIGN KEY (code_id) REFERENCES code (id),
@@ -256,8 +256,8 @@ VALUES
 -- ✅ code_highlight
 INSERT INTO code_highlight (user_id, code_id, start_pos, end_pos, color, memo)
 VALUES
-    (1, 1, '1:1', '1:10', 'yellow', 'main logic'),
-    (2, 2, '2:5', '2:15', 'red', 'bug here');
+    (1, 1, '1:1', '1:10', 'YELLOW', 'main logic'),
+    (2, 2, '2:5', '2:15', 'RED', 'bug here');
 
 -- ✅ chatbot
 INSERT INTO chatbot (team_id, test_date, message)


### PR DESCRIPTION
## 🔗 관련 이슈 번호  -->

- Closes #67 
- Closes #35 

## 🛠️ PR 유형
<!-- 어떤 변경 사항이 있나요? -->
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 작업 내용
- QueryDsl 의존성 추가 
- 히스토리 페이지 기능 개발 
- 로그인 시 user_id, team_id 응답객체에 추가 

## ✅ 변경 사항

- QueryDsl 의존성 추가 
- 히스토리 페이지 기능 개발 
- 로그인 시 user_id, team_id 응답객체에 추가 

## 📸 스크린샷 (선택)

## 💬 코멘트

- 리뷰 시 참고하거나 봐줬으면 하는 부분이 있다면 작성해주세요.
