### PR TITLE
[chore] Application.java에서 setTimeZone 시간대 지정

### DIFF
--- a/src/main/java/programo/_pro/Application.java
+++ b/src/main/java/programo/_pro/Application.java
@@ -1,5 +1,6 @@
 package programo._pro;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -7,6 +8,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.lang.NonNull;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableScheduling
@@ -32,5 +35,8 @@ public class Application {
         };
     }
 
-
+    @PostConstruct
+    public void setTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 번호 <!--- ex) 이슈 번호를 작성해주세요 close #11 -->

- Closes #81 

## 🛠️ PR 유형
<!-- 어떤 변경 사항이 있나요? -->
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 작업 내용

- Application.java에 다음 코드 삽입
`@PostConstruct
    public void setTimeZone() {
        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
    }`
- 로그 시간대, 데이터 모두 UTC(미국, JVM 기본설정) 에서 한국으로 변경
<!-- 예: 로그인 UI 수정, API 연결, 유효성 검사 추가 등 -->

## ✅ 변경 사항

- JVM 전체의 기본 타임존이 Asia/Seoul로 설정

<!-- 예: - UI 버튼 위치 변경
- 로그인 실패 시 에러 메시지 추가
- API 연결 시 토큰 헤더 포함  -->

## 📸 스크린샷 (선택)

## 💬 코멘트


